### PR TITLE
Fixed errors with new versions of Dancer2

### DIFF
--- a/lib/Dancer2/Plugin/Deferred.pm
+++ b/lib/Dancer2/Plugin/Deferred.pm
@@ -10,7 +10,7 @@ use Carp qw/croak/;
 use URI;
 use URI::QueryParam;
 
-use Dancer2::Plugin 0.05;
+use Dancer2::Plugin qw(:no_dsl);
 
 my $conf;
 
@@ -88,7 +88,7 @@ sub _get_conf {
         params_key         => 'dpdid',
         session_key_prefix => 'dpd_',
         template_key       => 'deferred',
-        %{ plugin_setting() },
+        
     };
 }
 


### PR DESCRIPTION
I have added the ":no_dsl" flag for Dancer2::Plugin and removed the call for plugin_setting because it was returning and error(Exception caught in 'core.app.before_request' filter: Hook error: Can't locate object method "dancer_app" via package "Dancer2::Plugin::Deferred" at /home/evodev/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/Dancer2/Plugin.pm line 123.)
