### PR TITLE
Update the test to mach Dancer2 changes

### DIFF
--- a/t/keep.t
+++ b/t/keep.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More 0.96 import => ['!pass'];
 use Test::TCP;
 
-use Dancer2 ':syntax';
+use Dancer2;
 use Dancer2::Plugin::Deferred;
 use LWP::UserAgent;
 


### PR DESCRIPTION
Fixed the following error: parameters must be key/value pairs, ':script' or '!keyword' at /home/evodev/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/Dancer2.pm line 45.
BEGIN failed--compilation aborted at t/keep.t line 7.
